### PR TITLE
Add argument for global parameters.

### DIFF
--- a/src/ApiManager.php
+++ b/src/ApiManager.php
@@ -24,7 +24,7 @@ class ApiManager implements ApiManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function createSubscriber(string $email, int $groupId, bool $active = false, array $attributes = [], array $globalAttributes)
+    public function createSubscriber(string $email, int $groupId, bool $active = false, array $attributes = [], array $globalAttributes = [])
     {
         $now = time();
 

--- a/src/ApiManager.php
+++ b/src/ApiManager.php
@@ -24,25 +24,20 @@ class ApiManager implements ApiManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function createSubscriber(string $email, int $groupId, bool $active = false, array $attributes = [])
+    public function createSubscriber(string $email, int $groupId, bool $active = false, array $attributes = [], array $globalAttributes)
     {
         $now = time();
 
         return $this->adapter->action(
             'post',
             "/v3/groups.json/{$groupId}/receivers",
-            array_merge(
-                [
-                    'email' => $email,
-                ],
-                [
-                    'registered' => $now,
-                    'activated' => $active ? $now : 0,
-                ],
-                [
-                    'attributes' => $attributes,
-                ]
-            )
+            [
+                'email' => $email,
+                'registered' => $now,
+                'activated' => $active ? $now : 0,
+                'attributes' => $attributes,
+                'global_attributes' => $globalAttributes,
+            ]
         );
     }
 


### PR DESCRIPTION
If it wasn't a BC break, it might make sense to allow overwriting of any request parameters in createSubscriber(), so that you can set or overwrite defaults of stuff like "orders", "tags" or "source". But for now I added another parameter to allow setting of the global parameters.